### PR TITLE
feat: Add desktop hyprland option

### DIFF
--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -63,18 +63,14 @@ let
 
     services.upower.enable = true;
 
-    services.xserver.enable = true;
-    services.xserver.enableCtrlAltBackspace = true;
-    services.xserver.xkb = {
-      layout = "us";
-      variant = "altgr-intl";
-      options = "eurosign:e";
+    services.displayManager = {
+      enable = true;
+      logToFile = true;
     };
 
     services.displayManager.logToFile = true;
-    services.xserver.displayManager.gdm.enable = ! cfg.wayland.enable;
+    services.xserver.displayManager.gdm.enable = ! (cfg.wayland.enable);
     services.xserver.wacom.enable = true;
-    services.xserver.desktopManager.xterm.enable = true;
 
     fonts.packages = with pkgs; [
       font-awesome
@@ -105,7 +101,23 @@ let
     };
   };
 
+  x11 = {
+    services.xserver = {
+      enable = true;
+      enableCtrlAltBackspace = true;
+      xkb = {
+        layout = "us";
+        variant = "altgr-intl";
+        options = "eurosign:e";
+      };
+
+      desktopManager.xterm.enable = true;
+    };
+  };
+
   wayland = {
+    services.xserver.desktopManager.xterm.enable = true;
+
     # services.xserver.displayManager.gdm.wayland = true;
     programs.regreet = {
       enable = true;
@@ -127,6 +139,36 @@ let
     # programs.river.enable = true;
   };
 
+  hyprland = {
+    services.xserver.displayManager.gdm.enable = true;
+
+    environment.sessionVariables = {
+      NIXOS_OZONE_WL = "1";
+    };
+
+    programs = {
+      hyprland = {
+        enable = true;
+      };
+
+      hyprlock = {
+        enable = true;
+      };
+
+      waybar = {
+        enable = true;
+      };
+    };
+
+    security = {
+      pam.services.hyprlock = {
+        text = ''
+          auth include login
+        '';
+      };
+    };
+  };
+
   keybase = {
     services.keybase.enable = true;
     services.kbfs = {
@@ -140,13 +182,17 @@ in
 {
   options.features.desktop = {
     enable = mkEnableOption "Enable desktop configs";
-    keybase.enable = mkEnableOption "Enable Keybase";
+    x11.enable = mkEnableOption "Enable X11";
     wayland.enable = mkEnableOption "Enable Wayland";
+    hyprland.enable = mkEnableOption "Enable Hyprland";
+    keybase.enable = mkEnableOption "Enable Keybase";
   };
 
   config = mkMerge [
     (mkIf cfg.enable configuration)
+    (mkIf cfg.x11.enable x11)
     (mkIf cfg.wayland.enable wayland)
+    (mkIf cfg.hyprland.enable hyprland)
     (mkIf cfg.keybase.enable keybase)
   ];
 }


### PR DESCRIPTION
Note that if you login with just this, you will not be able to open a terminal. Hyprland has a default config that expects `kitty` term to be installed. So either install it before you login, or just update the conf (`~/.config/hypr/hyprland.conf`) in a tty