### PR TITLE
Upower enabled by default

### DIFF
--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -61,7 +61,7 @@ let
     services.printing.enable = true;
     services.printing.drivers = [ pkgs.hplip ];
 
-    services.upower.enable = true;
+    services.upower.enable = lib.mkDefault true;
 
     services.displayManager = {
       enable = true;


### PR DESCRIPTION
It currently conflicts with a `plasma` upower setting [here](https://github.com/NixOS/nixpkgs/blob/dfb38ac8f358893f6544ae2e12cb2ab383ba031d/nixos/modules/services/desktop-managers/plasma6.nix#L268)